### PR TITLE
Add gitignore for environment files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,14 @@
+# Python
+__pycache__/
+*.py[cod]
+*$py.class
+
+# Virtual environment
+.venv/
+
+# Environment variables
+.env
+.env.*
+
+# macOS
+.DS_Store


### PR DESCRIPTION
## Summary
- ignore Python build artifacts and OS files
- exclude `.env` and variants
- add `.venv` to ignore Python virtual environment

## Testing
- `python -m py_compile backend/*.py`

------
https://chatgpt.com/codex/tasks/task_e_6843b3b9731c8329a87c783c2eeb3fc0